### PR TITLE
remove inline onclick handler for CSP

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-autocomplete.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-autocomplete.js.es6
@@ -26,7 +26,7 @@ export default {
         footer: `
           <div class="aa-footer">
             <div class="left-container">
-              <a class="advanced-search" onclick="document.location.href='/search'; document.reload();" href="/search">advanced search</a>
+              <a class="advanced-search" href="/search">advanced search</a>
             </div>
             <div class="right-container">
               <a target="_blank" class="algolia-logo" href="https://algolia.com/"


### PR DESCRIPTION
The `onclick` handler does two things: go to `/search` and refresh the page.

The link itself already goes to `/search` without needing `onclick`, but I am not sure what the refresh is for.

For ref this is the original commit that added this line - https://github.com/discourse/discourse-algolia/commit/d3eb70075c9e61672b8a9132419dd00aaabc6476 