### PR TITLE
chore: Remove Algolia Answers capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Populate the settings as follows:
 
 - **algolia enabled**: Check this box to enable indexing new content with Algolia.
 - **algolia autocomplete enabled**: Check this box to replace the default Discourse autocomplete with the Algolia autocomplete. It is recommended to do this only once you have all content indexed (see below).
-- **algolia answers enabled**: Check this box to use [Algolia Answers](https://www.algolia.com/doc/guides/algolia-ai/answers/) to search Posts semantically.
 - **algolia application id**: The ID of an Algolia application you have created.
 - **algolia search api key**: A search-only API key of the Algolia application. Do not use an admin API key, as this will be visible to the clients of your Discourse.
 - **algolia admin api key**: The admin API key of your Discourse application, or any API key that can write and configure indices.

--- a/assets/javascripts/discourse/initializers/discourse-algolia.js
+++ b/assets/javascripts/discourse/initializers/discourse-algolia.js
@@ -19,52 +19,9 @@ function initializeAutocomplete(options) {
 
   const hitsPerPage = 4;
 
-  // When Algolia Answers is enabled, use a different endpoint
-  const postsSourceFallback = autocomplete.sources.hits(postsIndex, {
+  const postsSource = autocomplete.sources.hits(postsIndex, {
     hitsPerPage,
   });
-
-  const postsSource = !options.algoliaAnswersEnabled
-    ? postsSourceFallback
-    : function (query, callback) {
-        const data = {
-          query,
-          queryLanguages: ["en"],
-          attributesForPrediction: ["content"],
-          nbHits: hitsPerPage,
-        };
-
-        fetch(
-          `https://${options.algoliaApplicationId}-dsn.algolia.net/1/answers/${postsIndex.indexName}/prediction`,
-          {
-            method: "POST",
-            headers: {
-              "X-Algolia-Application-Id": options.algoliaApplicationId,
-              "X-Algolia-API-Key": options.algoliaSearchApiKey,
-            },
-            body: JSON.stringify(data),
-          }
-        )
-          .then((response) => response.json())
-          .then((res) => {
-            if (!res.hits) {
-              throw new Error(`Invalid response: ${res.message}`);
-            } else {
-              res.hits.forEach((hit) => {
-                if ("_answer" in hit && "extract" in hit["_answer"]) {
-                  hit["_snippetResult"]["content"]["value"] =
-                    hit["_answer"]["extract"];
-                }
-              });
-              callback(res.hits);
-            }
-          })
-          .catch((err) => {
-            // eslint-disable-next-line no-console
-            console.error("[Algolia Answers]", err);
-            return postsSourceFallback(query, callback);
-          });
-      };
 
   return autocomplete(
     "#search-box",
@@ -254,8 +211,6 @@ export default {
               this._search = initializeAutocomplete({
                 algoliaApplicationId: this.siteSettings.algolia_application_id,
                 algoliaSearchApiKey: this.siteSettings.algolia_search_api_key,
-                algoliaAnswersEnabled: this.siteSettings
-                  .algolia_answers_enabled,
                 imageBaseURL: "",
                 debug: document.location.host.indexOf("localhost") > -1,
                 onSelect(event, suggestion) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,8 +2,7 @@ en:
   site_settings:
     algolia_enabled: "Enable the discourse-algolia plugin and send data to Algolia for indexing"
     algolia_autocomplete_enabled: "Enable the Algolia autocomplete in the site header"
-    algolia_answers_enabled: "Use <a href='https://www.algolia.com/doc/guides/algolia-ai/answers/'>Algolia Answers</a> when searching posts"
     algolia_application_id: "The Algolia app ID where data should be sent for indexing"
     algolia_admin_api_key: "An Algolia API key with permissions to write data and configure indices"
-    algolia_search_api_key: "An Algolia API key with <b>search</b> permission, used for the front end<br /><i>When Answers is enabled, it needs the </i><b>nluReadAnswers</b><i> permission too</i>"
+    algolia_search_api_key: "An Algolia API key with <b>search</b> permission, used for the front end<br />"
     algolia_discourse_username: "The data indexed will contain only objects that this user can see"

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -8,7 +8,6 @@ es:
   site_settings:
     algolia_enabled: "Activar el plugin discourse-algolia y enviar datos a Algolia para su indexación"
     algolia_autocomplete_enabled: "Activar el autocompletado de Algolia en el encabezado del sitio"
-    algolia_answers_enabled: "Usar las <a href='https://www.algolia.com/doc/guides/algolia-ai/answers/'>Respuestas de Algolia</a> al buscar publicaciones"
     algolia_application_id: "El ID de la aplicación Alglia al que se deben enviar los datos para la indexación"
     algolia_admin_api_key: "Una clave de API de Alglia con permisos para escribir datos y configurar índices"
     algolia_search_api_key: "Una clave de API de Alglia con permiso <b>search</b>, utilizada para el front-end<br /><i>Cuando Respuestas está habilitado, también necesita el permiso </i><b>BlueReadAnswers</b><i></i>"

--- a/config/locales/server.ja.yml
+++ b/config/locales/server.ja.yml
@@ -8,7 +8,6 @@ ja:
   site_settings:
     algolia_enabled: "discourse-algolia プラグインを有効にし、Algolia にデータを送信してインデックスを作成する"
     algolia_autocomplete_enabled: "サイトヘッダーで Algolia オートコンプリートを有効にする"
-    algolia_answers_enabled: "投稿を検索するときに <a href='https://www.algolia.com/doc/guides/algolia-ai/answers/'>Algolia Answers</a> を使用する"
     algolia_application_id: "データを送信してインデックスを作成する Algolia アプリ ID"
     algolia_admin_api_key: "データの書き込みとインデックスの構成を行う権限を持つ Algolia API キー"
     algolia_search_api_key: "フロントエンドで使用する、<b>検索</b>権限を持つ Algolia API キー。<br /><i>Answers が有効である場合は、</i><b>nluReadAnswers</b><i> 権限も必要です</i>"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,9 +5,6 @@ plugins:
   algolia_autocomplete_enabled:
     default: false
     client: true
-  algolia_answers_enabled:
-    default: false
-    client: true
   algolia_application_id:
     default: ""
     client: true


### PR DESCRIPTION
Hi there! As we are sunsetting Algolia Answers on November 1st, this PR removes the integration of the Answers API in the Discourse plugin (initially shipped as #23).

I didn't dare changing the translations beyond the english one and removing the `algolia_answers_enabled` key. It is worth going through existing translations to review `site_settings.algolia_search_api_key` accordingly. 