### PR TITLE
DEV: Run db migrations under `ActiveRecord::Migration[6.1]`

### DIFF
--- a/db/post_migrate/20221030230455_remove_algolia_answers_enabled_site_setting.rb
+++ b/db/post_migrate/20221030230455_remove_algolia_answers_enabled_site_setting.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveAlgoliaAnswersEnabledSiteSetting < ActiveRecord::Migration[7.0]
+class RemoveAlgoliaAnswersEnabledSiteSetting < ActiveRecord::Migration[6.1]
   def up
     execute <<~SQL
       DELETE FROM site_settings


### PR DESCRIPTION
This is to ensure that the plugin is backwards compatibile with
Discourse core's `stable` branch which is still running Rails 6.1.

I could have technically added a `.discourse-compatibility` file but I
didn't think it was necessary considering that migration does not depend
on any ActiveRecord::Migration APIs so we can just run it using the
6.1 version.