### PR TITLE
FIX: Remove reference to `Tag#topic_count` which was removed in core

### DIFF
--- a/lib/discourse_algolia/tag_indexer.rb
+++ b/lib/discourse_algolia/tag_indexer.rb
@@ -15,10 +15,14 @@ class DiscourseAlgolia::TagIndexer < DiscourseAlgolia::Indexer
   end
 
   def should_index?(tag)
-    @guardian.can_see?(tag) && tag.topic_count > 0
+    @guardian.can_see?(tag) && topic_count_for_tag(tag) > 0
   end
 
   def to_object(tag)
-    { objectID: tag.id, url: tag.url, name: tag.name, topic_count: tag.topic_count }
+    { objectID: tag.id, url: tag.url, name: tag.name, topic_count: topic_count_for_tag(tag) }
+  end
+
+  def topic_count_for_tag(tag)
+    tag.public_send(Tag.topic_count_column(@guardian))
   end
 end

--- a/spec/lib/discourse_algolia/tag_indexer_spec.rb
+++ b/spec/lib/discourse_algolia/tag_indexer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+describe DiscourseAlgolia::TagIndexer do
+  let(:subject) { DiscourseAlgolia.indexer(:tag) }
+
+  fab!(:user) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:group) { Fabricate(:group) }
+  fab!(:tag) { Fabricate(:tag) }
+  fab!(:public_category) { Fabricate(:category) }
+  fab!(:read_restricted_category) { Fabricate(:private_category, group: group) }
+  fab!(:topic_in_public_category) { Fabricate(:topic, category: public_category, tags: [tag]) }
+
+  fab!(:topic_in_read_restricted_category) do
+    Fabricate(:topic, category: read_restricted_category, tags: [tag])
+  end
+
+  before { setup_algolia_tests }
+
+  it "enqueues a tag for indexing" do
+    subject
+      .index
+      .expects(:save_objects)
+      .with([{ objectID: tag.id, url: tag.url, name: tag.name, topic_count: 1 }])
+
+    subject.process!(ids: [tag.id])
+  end
+
+  it "enqueues a tag for indexing with Tag#staff_topic_count if `algolia_discourse_username` site setting is configured to a staff user" do
+    SiteSetting.algolia_discourse_username = admin.username
+
+    subject
+      .index
+      .expects(:save_objects)
+      .with([{ objectID: tag.id, url: tag.url, name: tag.name, topic_count: 2 }])
+
+    subject.process!(ids: [tag.id])
+  end
+
+  it "enqueues a tag for indexing with Tag#staff_topic_count if `include_secure_categories_in_tag_counts` site setting is enabled" do
+    SiteSetting.include_secure_categories_in_tag_counts = true
+
+    subject
+      .index
+      .expects(:save_objects)
+      .with([{ objectID: tag.id, url: tag.url, name: tag.name, topic_count: 2 }])
+
+    subject.process!(ids: [tag.id])
+  end
+end


### PR DESCRIPTION
Discourse core commit f122f24b35a8116e47649ae139910d44e3d7488e removed
`Tag#topic_count` as part of a security fix. This commit updates the
plugin to rely on `Tag.topic_count_column` instead which ensures that
the tag topic count being indexed by default does not include read
restricted topic.