### PR TITLE
FIX: index only public topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Populate the settings as follows:
 - **algolia application id**: The ID of an Algolia application you have created.
 - **algolia search api key**: A search-only API key of the Algolia application. Do not use an admin API key, as this will be visible to the clients of your Discourse.
 - **algolia admin api key**: The admin API key of your Discourse application, or any API key that can write and configure indices.
-- **algolia discourse username**: If content is visible to this Discourse user, it will be indexed. If not, it will be skipped. This defaults to `system`, which is an admin account and can see content in all categories, including Staff. (Private messages, however, are always excluded from indexing.) It is recommended that you create a dummy separate user who can only see content you consider to be public, and change this value to their username.
 
 You can find the **algolia application id**, **algolia search api key**, and **algolia admin api key** in the **API Keys** page of your [Algolia dashboard](https://algolia.com/dashboard/).
 

--- a/assets/javascripts/discourse/initializers/discourse-algolia.js
+++ b/assets/javascripts/discourse/initializers/discourse-algolia.js
@@ -327,7 +327,9 @@ export default {
       api.decorateWidget("header-icons:before", function (helper) {
         if (
           helper.widget.siteSettings.algolia_enabled &&
-          helper.widget.siteSettings.algolia_autocomplete_enabled
+          helper.widget.siteSettings.algolia_autocomplete_enabled &&
+          (!helper.widget.siteSettings.login_required ||
+            helper.widget.currentUser)
         ) {
           return helper.attach("algolia");
         }

--- a/config/locales/server.ar.yml
+++ b/config/locales/server.ar.yml
@@ -11,4 +11,3 @@ ar:
     algolia_application_id: "معرِّف تطبيق Algolia حيث يجب إرسال البيانات لفهرستها"
     algolia_admin_api_key: "مفتاح واجهة برمجة تطبيقات Algolia مع أذونات لكتابة البيانات وإعداد الفهارس"
     algolia_search_api_key: "مفتاح واجهة برمجة تطبيقات Algolia مع إذن <b>search</b>، ويتم استخدامه في الواجهة الأمامية<br /><i>عند تفعيل Answers، وهو بحاجة إلى إذن </i><b>nluReadAnswers</b><i> أيضًا</i>"
-    algolia_discourse_username: "ستتضمَّن البيانات المفهرسة الكائنات التي يمكن لهذا المستخدم رؤيتها فقط"

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -11,4 +11,3 @@ de:
     algolia_application_id: "Die Algolia-App-ID, an die Daten zur Indizierung gesendet werden sollen"
     algolia_admin_api_key: "Ein Algolia-API-Schlüssel mit Berechtigungen zum Schreiben von Daten und zum Konfigurieren von Indizes"
     algolia_search_api_key: "Ein Algolia-API-Schlüssel mit <b>Suchberechtigung</b>, der für das Frontend verwendet wird<br /><i>Wenn Answers aktiviert ist, wird zusätzlich die Berechtigung </i><b>nluReadAnswers</b><i> benötigt</i>"
-    algolia_discourse_username: "Die indizierten Daten enthalten nur Objekte, die dieser Benutzer sehen kann"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,4 +5,3 @@ en:
     algolia_application_id: "The Algolia app ID where data should be sent for indexing"
     algolia_admin_api_key: "An Algolia API key with permissions to write data and configure indices"
     algolia_search_api_key: "An Algolia API key with <b>search</b> permission, used for the front end<br /><i>When Answers is enabled, it needs the </i><b>nluReadAnswers</b><i> permission too</i>"
-    algolia_discourse_username: "The data indexed will contain only objects that this user can see"

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -11,4 +11,3 @@ es:
     algolia_application_id: "El ID de la aplicación Alglia al que se deben enviar los datos para la indexación"
     algolia_admin_api_key: "Una clave de API de Alglia con permisos para escribir datos y configurar índices"
     algolia_search_api_key: "Una clave de API de Alglia con permiso <b>search</b>, utilizada para el front-end<br /><i>Cuando Respuestas está habilitado, también necesita el permiso </i><b>BlueReadAnswers</b><i></i>"
-    algolia_discourse_username: "Los datos indexados contendrán solo objetos que este usuario pueda ver"

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -11,4 +11,3 @@ fi:
     algolia_application_id: "Algolian sovellustunnus, johon tiedot lähetetään indeksoitavaksi"
     algolia_admin_api_key: "Algolian API-avain, jolla on oikeudet kirjoittaa tietoja ja määrittää indeksejä"
     algolia_search_api_key: "Algolian API-avain, jolla on <b>haun</b> käyttöoikeus, käytetään käyttöliittymässä<br /><i>Kun Answers on käytössä, se tarvitsee myös </i><b>nluReadAnswers</b><i>-käyttöoikeuden</i>"
-    algolia_discourse_username: "Indeksoidut tiedot sisältävät vain objekteja, jotka tämä käyttäjä voi nähdä"

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -11,4 +11,3 @@ fr:
     algolia_application_id: "L'ID de l'application Algolia à laquelle les données doivent être envoyées pour indexation"
     algolia_admin_api_key: "Une clé API Algolia avec des autorisations pour écrire des données et configurer des index"
     algolia_search_api_key: "Une clé API Algolia avec une autorisation de <b>recherche</b>, utilisée pour le front-end<br /><i>Lorsque Answers est activé, elle a également besoin de l'autorisation </i><b>nluReadAnswers</b><i></i>"
-    algolia_discourse_username: "Les données indexées ne contiendront que des objets que cet utilisateur peut voir"

--- a/config/locales/server.he.yml
+++ b/config/locales/server.he.yml
@@ -11,4 +11,3 @@ he:
     algolia_application_id: "מזהה יישום Algolia אליו אמורים הנתונים להישלח לסידור באינדקס"
     algolia_admin_api_key: "מפתח API של Algolia עם הרשות לכתוב נתונים ולהגדיר אינדקסים"
     algolia_search_api_key: "מפתח API של Algolia עם הרשאת <b>חיפוש</b>, משמש את מנשק המשתמש<br /><i>כאשר Answers (תשובות) פעילות, נדרשת <i>גם ההרשאה </i><b>nluReadAnswers</b>"
-    algolia_discourse_username: "הנתונים שמסודרים באינדקס יכילו רק עצמים שהמשתמש הזה יכול לראות"

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -11,4 +11,3 @@ it:
     algolia_application_id: "L'ID dell'app Algolia a cui inviare i dati per l'indicizzazione"
     algolia_admin_api_key: "Una chiave API Algolia con autorizzazioni per la scrittura dei dati e la configurazione di indici"
     algolia_search_api_key: "Una chiave API Algolia con autorizzazione di <b>ricerca</b>, utilizzata per il front-end<br /><i>Quando Answers è abilitato, necessita anche dell'autorizzazione </i><b>nluReadAnswers</b><i></i>"
-    algolia_discourse_username: "I dati indicizzati conterranno solo oggetti visibili a questo utente"

--- a/config/locales/server.ja.yml
+++ b/config/locales/server.ja.yml
@@ -11,4 +11,3 @@ ja:
     algolia_application_id: "データを送信してインデックスを作成する Algolia アプリ ID"
     algolia_admin_api_key: "データの書き込みとインデックスの構成を行う権限を持つ Algolia API キー"
     algolia_search_api_key: "フロントエンドで使用する、<b>検索</b>権限を持つ Algolia API キー。<br /><i>Answers が有効である場合は、</i><b>nluReadAnswers</b><i> 権限も必要です</i>"
-    algolia_discourse_username: "インデックスが作成されるデータには、このユーザーが表示できるオブジェクトのみが含まれます"

--- a/config/locales/server.nl.yml
+++ b/config/locales/server.nl.yml
@@ -11,4 +11,3 @@ nl:
     algolia_application_id: "De Algolia-app-ID waarnaar gegevens moeten worden gestuurd voor indexering"
     algolia_admin_api_key: "Een Algolia-API-sleutel met machtigingen om gegevens te schrijven en indexen te configureren"
     algolia_search_api_key: "Een Algolia-API-sleutel met <b>zoekrechten</b> , gebruikt voor de frontend<br /><i>Als Antwoorden is ingeschakeld, vereist deze ook het recht </i><b>nluReadAnswers</b><i></i>"
-    algolia_discourse_username: "De geïndexeerde gegevens bevatten alleen objecten die deze gebruiker kan zien"

--- a/config/locales/server.pl_PL.yml
+++ b/config/locales/server.pl_PL.yml
@@ -11,4 +11,3 @@ pl_PL:
     algolia_application_id: "Identyfikator aplikacji Algolia, do którego należy przesłać dane do indeksowania"
     algolia_admin_api_key: "Klucz API Algolia z uprawnieniami do zapisu danych i konfiguracji indeksów"
     algolia_search_api_key: "Klucz Algolia API z uprawnieniem do <b>wyszukiwania</b> , używany na front-endzie<br /><i>Gdy włączona jest opcja Answers, potrzebuje ona również uprawnienia </i><b>nluReadAnswers</b>."
-    algolia_discourse_username: "Zindeksowane dane będą zawierać tylko obiekty, które ten użytkownik może zobaczyć"

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -11,4 +11,3 @@ pt_BR:
     algolia_application_id: "A ID do app Algolia para o qual os dados devem ser enviados para indexação"
     algolia_admin_api_key: "A chave de API com permissões para gravar dados e configurar índices"
     algolia_search_api_key: "Uma chave de API do Algolia com permissão de <b>pesquisa</b>, usada para o front-end<br /><i>Ao ativar Respostas, é preciso ter a permissão </i><b>nluReadAnswers</b><i> também"
-    algolia_discourse_username: "Os dados indexados conterão apenas objetos que este(a) usuário(a) pode ver"

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -11,4 +11,3 @@ ru:
     algolia_application_id: "Идентификатор Algolia, куда следует отправлять данные для индексации"
     algolia_admin_api_key: "Ключ API Algolia с разрешениями на запись данных и настройку индексов"
     algolia_search_api_key: "Ключ API Algolia с разрешением на <b>поиск</b>, используется для фронтенда<br /><i>Когда используются Algolia Answers, также требуется разрешение </i><b>nluReadAnswers</b>"
-    algolia_discourse_username: "Проиндексированные данные будут содержать только те объекты, которые может видеть этот пользователь"

--- a/config/locales/server.sv.yml
+++ b/config/locales/server.sv.yml
@@ -11,4 +11,3 @@ sv:
     algolia_application_id: "Algolia app-ID där data ska skickas för indexering"
     algolia_admin_api_key: "En Algolia API-nyckel med behörighet att skriva data och konfigurera index"
     algolia_search_api_key: "En Algolia API-nyckel med <b>sök</b> behörighet, används för besöksidan<br /><i>När Svar är aktiverat behöver den också behörighet till </i><b>nluReadAnswers</b>"
-    algolia_discourse_username: "Data som indexeras innehåller endast objekt som den här användaren kan se"

--- a/config/locales/server.tr_TR.yml
+++ b/config/locales/server.tr_TR.yml
@@ -11,4 +11,3 @@ tr_TR:
     algolia_application_id: "İndeksleme için verilerin gönderilmesi gereken Algolia uygulama kimliği"
     algolia_admin_api_key: "Veri yazma ve endeksleri yapılandırma izinlerine sahip bir Algolia API anahtarı"
     algolia_search_api_key: "Ön uç için kullanılan <b>ara</b> iznine sahip bir Algolia API anahtarı<br /><i> Yanıtlar etkinleştirildiğinde, </i><b>nluReadAnswers</b><i> iznine de ihtiyaç duyar</i>"
-    algolia_discourse_username: "İndekslenen veriler yalnızca bu kullanıcının görebileceği nesneleri içerir"

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -11,4 +11,3 @@ zh_CN:
     algolia_application_id: "应发送数据进行索引的 Algolia 应用 ID"
     algolia_admin_api_key: "具有写入数据和配置索引权限的 Algolia API 密钥"
     algolia_search_api_key: "具有<b>搜索</b>权限的 Algolia API 密钥，用于前端<br /><i>启用 Answers 后，它也需要 </i><b>nluReadAnswers</b><i> 权限</i>"
-    algolia_discourse_username: "索引的数据将仅包含此用户可以看到的对象"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,5 +14,3 @@ plugins:
   algolia_admin_api_key:
     default: ""
     secret: true
-  algolia_discourse_username:
-    default: ""

--- a/db/post_migrate/20230227224945_remove_algolia_discourse_username_site_settings.rb
+++ b/db/post_migrate/20230227224945_remove_algolia_discourse_username_site_settings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveAlgoliaDiscourseUsernameSiteSettings < ActiveRecord::Migration[7.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'algolia_discourse_username'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/post_migrate/20230228024641_reindex_all_topics.rb
+++ b/db/post_migrate/20230228024641_reindex_all_topics.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ReindexAllTopics < ActiveRecord::Migration[7.0]
+  def up
+    post_ids = execute("SELECT id FROM posts WHERE post_number = 1").map { |r| r["id"].to_i }
+
+    post_ids.in_groups_of(500) do |batch|
+      Discourse.redis.rpush("algolia-first-posts", batch.compact)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/discourse_algolia.rb
+++ b/lib/discourse_algolia.rb
@@ -15,8 +15,7 @@ class DiscourseAlgolia
         SiteSetting.algolia_application_id,
         SiteSetting.algolia_admin_api_key,
       )
-    user = User.find_by_username(SiteSetting.algolia_discourse_username)
-    guardian = Guardian.new(user)
+    guardian = Guardian.new
 
     case type.to_sym
     when :user

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-algolia
 # about: Use Algolia to power the search on your Discourse
-# version: 0.4.0
+# version: 0.4.1
 # authors: Josh Dzielak, Gianluca Bargelli, Paul-Louis Nech
 # url: https://github.com/discourse/discourse-algolia
 # transpile_js: true

--- a/spec/lib/discourse_algolia/tag_indexer_spec.rb
+++ b/spec/lib/discourse_algolia/tag_indexer_spec.rb
@@ -26,17 +26,6 @@ describe DiscourseAlgolia::TagIndexer do
     subject.process!(ids: [tag.id])
   end
 
-  it "enqueues a tag for indexing with Tag#staff_topic_count if `algolia_discourse_username` site setting is configured to a staff user" do
-    SiteSetting.algolia_discourse_username = admin.username
-
-    subject
-      .index
-      .expects(:save_objects)
-      .with([{ objectID: tag.id, url: tag.url, name: tag.name, topic_count: 2 }])
-
-    subject.process!(ids: [tag.id])
-  end
-
   it "enqueues a tag for indexing with Tag#staff_topic_count if `include_secure_categories_in_tag_counts` site setting is enabled" do
     SiteSetting.include_secure_categories_in_tag_counts = true
 

--- a/test/javascripts/acceptance/algolia-search-test.js
+++ b/test/javascripts/acceptance/algolia-search-test.js
@@ -1,5 +1,6 @@
 import {
   acceptance,
+  exists,
   query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -15,7 +16,6 @@ acceptance("Discourse Algolia - Search", function (needs) {
     algolia_application_id: "123",
     algolia_search_api_key: "key",
     algolia_admin_api_key: "adminkey",
-    algolia_discourse_username: "system",
   });
   needs.site({ can_tag_topics: true });
 
@@ -240,5 +240,11 @@ acceptance("Discourse Algolia - Search", function (needs) {
     );
     await click(".hit-tag-name");
     assert.strictEqual(currentURL(), "/tag/bug", "redirects to tag page");
+  });
+
+  test("search not visible when site is requiring login", async function (assert) {
+    this.siteSettings.login_required = true;
+    await visit("/");
+    assert.ok(!exists(document.querySelector(".algolia-search")));
   });
 });


### PR DESCRIPTION
`algolia discourse username` setting was potentially dangerous. When admin is used, topic from restricted categories and private messages can be exposed.

Therefore, the setting should be removed and only topics visible to anonymous user should be indexed.

In addition, when site requires login, Algolia search should not be visible for anonymous users.