### PR TITLE
FIX: Show default core search icon on mobile

### DIFF
--- a/assets/stylesheets/discourse-algolia-base.scss
+++ b/assets/stylesheets/discourse-algolia-base.scss
@@ -1,6 +1,6 @@
 /* make changes to discourse styling outside the affected widgets
    only when the algolia plugin has been enabled */
-body.algolia-enabled {
+html:not(.mobile-view) body.algolia-enabled {
   /* don't let topic titles run into the search bar */
   .extra-info-wrapper {
     max-width: 300px;


### PR DESCRIPTION
This plugin only exposes the Algolia widget on desktop. But it hides the default core search icon (via CSS) on both desktop and mobile. This PR makes a trivial change to only hide the core icon on desktop.

This allows users on mobile to still use Discourse's own search.