### PR TITLE
DEV: Replace deprecated min_trust_to_create_post

### DIFF
--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe DiscourseAlgolia do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:admin) { Fabricate(:admin) }
   fab!(:post) { Fabricate(:post, post_number: 1) }
   fab!(:post_2) { Fabricate(:post, topic: post.topic, post_number: 2) }


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/24740, `min_trust_to_create_topic` site setting was replaced by `create_topic_allowed_groups`. This PR replaces the former, deprecated one, with the latter.