### PR TITLE
DEV: Add extra `waitFor` in a test

### DIFF
--- a/test/javascripts/acceptance/algolia-search-test.js
+++ b/test/javascripts/acceptance/algolia-search-test.js
@@ -180,6 +180,7 @@ acceptance("Discourse Algolia - Search", function (needs) {
   test("search posts, users and tags", async function (assert) {
     await visit("/");
 
+    await waitFor(".aa-Input");
     await fillIn(".aa-Input", "internationalization");
     await waitFor(".hit-post-topic-title", { count: 1 });
 


### PR DESCRIPTION
The autocomplete is 3rd-party async code, we can never assume it's immediately ready.