### PR TITLE
DEV: Fix an algolia warning in tests

### DIFF
--- a/assets/javascripts/discourse/api-initializers/discourse-algolia.gjs
+++ b/assets/javascripts/discourse/api-initializers/discourse-algolia.gjs
@@ -301,8 +301,8 @@ export default apiInitializer((api) => {
 
   let search;
 
-  async function loadAlgoliaScripts() {
-    await Promise.all([
+  function loadAlgoliaScripts() {
+    return Promise.all([
       loadScript("/plugins/discourse-algolia/javascripts/autocomplete.js"),
       loadScript("/plugins/discourse-algolia/javascripts/algoliasearch.js"),
     ]);
@@ -315,11 +315,7 @@ export default apiInitializer((api) => {
       await loadAlgoliaScripts();
     } catch {
       // Retry once
-      try {
-        await loadAlgoliaScripts();
-      } catch (error) {
-        throw error;
-      }
+      await loadAlgoliaScripts();
     }
 
     document.body.classList.add("algolia-enabled");

--- a/test/javascripts/acceptance/algolia-search-test.js
+++ b/test/javascripts/acceptance/algolia-search-test.js
@@ -74,6 +74,20 @@ acceptance("Discourse Algolia - Search", function (needs) {
                       fullyHighlighted: false,
                       matchedWords: ["internationalization"],
                     },
+                    tags: [
+                      {
+                        name: {
+                          value: "important",
+                          matchLevel: "none",
+                          matchedWords: [],
+                        },
+                        slug: {
+                          value: "important",
+                          matchLevel: "none",
+                          matchedWords: [],
+                        },
+                      },
+                    ],
                   },
                 },
               },


### PR DESCRIPTION
```
[Autocomplete] The attribute "topic.tags.0.name" described by the path ["topic","tags",0,"name"] does not exist on the hit. Did you set it in `attributesToHighlight`?
See https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/
```

Also a small cleanup after 0eb79a9587bc96e0c44db1172338b152785745b7