### PR TITLE
SECURITY: Harden security for login-required forums

### DIFF
--- a/assets/javascripts/discourse/api-initializers/discourse-algolia.gjs
+++ b/assets/javascripts/discourse/api-initializers/discourse-algolia.gjs
@@ -293,10 +293,13 @@ function initializeAutocomplete(options) {
 
 export default apiInitializer((api) => {
   const siteSettings = api.container.lookup("service:site-settings");
+  const site = api.container.lookup("service:site");
   const currentUser = api.getCurrentUser();
   const shouldDisplay = () =>
     siteSettings.algolia_enabled &&
     siteSettings.algolia_autocomplete_enabled &&
+    siteSettings.algolia_application_id &&
+    site.algolia_search_api_key &&
     (!siteSettings.login_required || currentUser);
 
   let search;
@@ -321,7 +324,7 @@ export default apiInitializer((api) => {
     document.body.classList.add("algolia-enabled");
     search = initializeAutocomplete({
       algoliaApplicationId: siteSettings.algolia_application_id,
-      algoliaSearchApiKey: siteSettings.algolia_search_api_key,
+      algoliaSearchApiKey: site.algolia_search_api_key,
       imageBaseURL: "",
       debug: isDevelopment(),
     });

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,6 @@ plugins:
     client: true
   algolia_search_api_key:
     default: ""
-    client: true
   algolia_admin_api_key:
     default: ""
     secret: true

--- a/lib/discourse_algolia/post_indexer.rb
+++ b/lib/discourse_algolia/post_indexer.rb
@@ -38,8 +38,14 @@ class DiscourseAlgolia::PostIndexer < DiscourseAlgolia::Indexer
     Post.includes(:user, topic: %i[tags category shared_draft]).where(id: ids)
   end
 
+  def process!(ids: nil)
+    return clear_index! if SiteSetting.login_required
+
+    super
+  end
+
   def should_index?(post)
-    @guardian.can_see?(post)
+    !SiteSetting.login_required && @guardian.can_see?(post)
   end
 
   def to_object(post)
@@ -84,5 +90,12 @@ class DiscourseAlgolia::PostIndexer < DiscourseAlgolia::Indexer
     end
 
     object
+  end
+
+  private
+
+  def clear_index!
+    @index.clear_objects
+    Discourse.redis.del(self.class::QUEUE_NAME)
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -36,6 +36,15 @@ after_initialize do
   require_relative "lib/discourse_algolia/topic_indexer"
   require_relative "lib/discourse_algolia/user_indexer"
 
+  add_to_serializer(
+    :site,
+    :algolia_search_api_key,
+    include_condition: -> do
+      SiteSetting.algolia_search_api_key.present? &&
+        (!SiteSetting.login_required || scope&.current_user.present?)
+    end,
+  ) { SiteSetting.algolia_search_api_key }
+
   %i[user_created user_updated user_destroyed].each do |event|
     on(event) { |user| DiscourseAlgolia::UserIndexer.enqueue(user.id) }
   end

--- a/spec/lib/discourse_algolia/post_indexer_spec.rb
+++ b/spec/lib/discourse_algolia/post_indexer_spec.rb
@@ -14,6 +14,16 @@ describe DiscourseAlgolia::PostIndexer do
     post_indexer.process!(ids: [post.id, pm_post.id])
   end
 
+  it "clears the post index when login is required" do
+    SiteSetting.login_required = true
+
+    post_indexer.index.expects(:clear_objects)
+    post_indexer.index.expects(:save_objects).never
+    post_indexer.index.expects(:delete_objects).never
+
+    post_indexer.process!(ids: [post.id])
+  end
+
   describe "#to_object" do
     fab!(:tag1) { Fabricate(:tag, name: "bug") }
     fab!(:tag2) { Fabricate(:tag, name: "feature-request") }

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -13,6 +13,38 @@ describe DiscourseAlgolia do
 
   before { setup_algolia_tests }
 
+  describe "Algolia search key exposure" do
+    it "keeps the search key out of global client settings and private anonymous site payloads" do
+      client_settings = JSON.parse(SiteSetting.client_settings_json_uncached)
+      expect(client_settings).not_to have_key("algolia_search_api_key")
+
+      public_guardian = Guardian.new
+      public_site =
+        SiteSerializer.new(Site.new(public_guardian), scope: public_guardian, root: false).as_json
+      expect(public_site[:algolia_search_api_key]).to eq("searchapikey")
+
+      SiteSetting.login_required = true
+
+      anonymous_guardian = Guardian.new
+      anonymous_site =
+        SiteSerializer.new(
+          Site.new(anonymous_guardian),
+          scope: anonymous_guardian,
+          root: false,
+        ).as_json
+      expect(anonymous_site).not_to have_key(:algolia_search_api_key)
+
+      authenticated_guardian = Guardian.new(user)
+      authenticated_site =
+        SiteSerializer.new(
+          Site.new(authenticated_guardian),
+          scope: authenticated_guardian,
+          root: false,
+        ).as_json
+      expect(authenticated_site[:algolia_search_api_key]).to eq("searchapikey")
+    end
+  end
+
   describe "users" do
     describe "event user_created" do
       it "enqueues new user" do

--- a/test/javascripts/acceptance/algolia-search-test.js
+++ b/test/javascripts/acceptance/algolia-search-test.js
@@ -13,7 +13,7 @@ acceptance("Discourse Algolia - Search", function (needs) {
     algolia_admin_api_key: "adminkey",
   });
 
-  needs.site({ can_tag_topics: true });
+  needs.site({ can_tag_topics: true, algolia_search_api_key: "key" });
 
   needs.pretender((server, helper) => {
     server.get(`/tag/1/l/latest.json`, () => {


### PR DESCRIPTION
## Summary

Prevent the unauthorized exposure of post content on login-required sites by disabling Algolia indexing and clearing existing indices when login is required. The patch also restricts the delivery of the Algolia search API key, removing it from global client settings and only exposing it to authenticated users on private sites.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1407
- Affected file: https://github.com/discourse/discourse-algolia/blob/main/plugin.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>