### PR TITLE
SECURITY: Stale Algolia indexing after category access revocation exposes private post content through the public search key

### DIFF
--- a/app/jobs/scheduled/update_indexes.rb
+++ b/app/jobs/scheduled/update_indexes.rb
@@ -5,7 +5,7 @@ module Jobs
     every 5.minutes
 
     def execute(args)
-      DiscourseAlgolia.process!
+      DiscourseAlgolia.process!(category_id: args[:category_id])
     end
   end
 end

--- a/lib/discourse_algolia.rb
+++ b/lib/discourse_algolia.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 class DiscourseAlgolia
-  def self.process!
+  def self.process!(category_id: nil)
     return if !SiteSetting.algolia_enabled?
 
     DistributedMutex.synchronize("algolia-queue", validity: 1.minute) do
-      %i[user tag topic post].each { |type| indexer(type).process! }
+      if category_id
+        indexer(:post).process_category!(category_id)
+      else
+        %i[user tag topic post].each { |type| indexer(type).process! }
+      end
     end
   end
 

--- a/lib/discourse_algolia/post_indexer.rb
+++ b/lib/discourse_algolia/post_indexer.rb
@@ -44,6 +44,15 @@ class DiscourseAlgolia::PostIndexer < DiscourseAlgolia::Indexer
     super
   end
 
+  def process_category!(category_id)
+    return clear_index! if SiteSetting.login_required
+
+    Post
+      .joins(:topic)
+      .where(topics: { category_id: category_id })
+      .in_batches(of: QUEUE_SIZE) { |posts| process!(ids: posts.pluck(:id)) }
+  end
+
   def should_index?(post)
     !SiteSetting.login_required && @guardian.can_see?(post)
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -53,6 +53,10 @@ after_initialize do
     on(event) { |tag| DiscourseAlgolia::TagIndexer.enqueue(tag.id) }
   end
 
+  add_model_callback(Category, :after_commit, on: :update) do
+    Jobs.enqueue(:update_indexes, category_id: id) if saved_change_to_read_restricted?
+  end
+
   on(:post_created) { |post| DiscourseAlgolia::PostIndexer.enqueue(post.id) }
 
   on(:post_edited) do |post, topic_changed|

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+class InMemoryAlgoliaIndex
+  attr_reader :objects
+
+  def initialize(search_api_key)
+    @search_api_key = search_api_key
+    @objects = {}
+  end
+
+  def exists?
+    true
+  end
+
+  def save_objects(objects)
+    objects.each { |object| @objects[object[:objectID]] = object }
+  end
+
+  def delete_objects(ids)
+    ids.each { |id| @objects.delete(id) }
+  end
+
+  def clear_objects
+    @objects.clear
+  end
+
+  def search(query, api_key:)
+    return [] if api_key != @search_api_key
+
+    @objects.values.select { |object| object[:content].include?(query) }
+  end
+end
+
+class InMemoryAlgoliaClient
+  def initialize(search_api_key)
+    @search_api_key = search_api_key
+    @indexes = {}
+  end
+
+  def init_index(name)
+    @indexes[name] ||= InMemoryAlgoliaIndex.new(@search_api_key)
+  end
+end
+
+RSpec.describe CategoriesController do
+  fab!(:admin)
+  fab!(:attacker, :user)
+  fab!(:category) { Fabricate(:category, user: admin) }
+  fab!(:secret_topic) { Fabricate(:topic, category: category) }
+  fab!(:secret_first_post) do
+    Fabricate(
+      :post,
+      topic: secret_topic,
+      post_number: 1,
+      raw: "Embargoed project Juniper starts next quarter",
+    )
+  end
+  fab!(:secret_reply) do
+    Fabricate(
+      :post,
+      topic: secret_topic,
+      post_number: 2,
+      raw: "Embargoed project Juniper has a confidential budget",
+    )
+  end
+  fab!(:public_post) { Fabricate(:post, raw: "Public control post") }
+
+  let(:algolia_client) { InMemoryAlgoliaClient.new(SiteSetting.algolia_search_api_key) }
+  let(:post_index) { algolia_client.init_index(DiscourseAlgolia::PostIndexer::INDEX_NAME) }
+
+  before do
+    setup_algolia_tests
+    Jobs.run_immediately!
+    Algolia::Search::Client.stubs(:create).returns(algolia_client)
+
+    DiscourseAlgolia.indexer(:post).process!(
+      ids: [secret_first_post.id, secret_reply.id, public_post.id],
+    )
+  end
+
+  describe "#update" do
+    it "synchronizes every post in the public Algolia index when category access changes" do
+      get "/site.json"
+
+      expect(response).to have_http_status(:ok)
+      anonymous_search_key = response.parsed_body["algolia_search_api_key"]
+      expect(anonymous_search_key).to eq(SiteSetting.algolia_search_api_key)
+      expect(
+        post_index.search("Embargoed project Juniper", api_key: anonymous_search_key),
+      ).to contain_exactly(
+        post_index.objects.fetch(secret_first_post.id),
+        post_index.objects.fetch(secret_reply.id),
+      )
+
+      sign_in(admin)
+      put "/categories/#{category.id}.json",
+          params: {
+            permissions: {
+              Group[:admins].name => CategoryGroup.permission_types[:full],
+            },
+          }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig("category", "read_restricted")).to eq(true)
+
+      sign_out
+      sign_in(attacker)
+      get "/t/#{secret_topic.id}.json"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to include(secret_first_post.raw)
+      expect(
+        post_index.search("Embargoed project Juniper", api_key: anonymous_search_key),
+      ).to be_empty
+      expect(post_index.objects.keys).to contain_exactly(public_post.id)
+
+      sign_in(admin)
+      put "/categories/#{category.id}.json",
+          params: {
+            permissions: {
+              Group[:everyone].name => CategoryGroup.permission_types[:full],
+            },
+          }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig("category", "read_restricted")).to eq(false)
+      expect(
+        post_index.search("Embargoed project Juniper", api_key: anonymous_search_key),
+      ).to contain_exactly(
+        post_index.objects.fetch(secret_first_post.id),
+        post_index.objects.fetch(secret_reply.id),
+      )
+      expect(post_index.objects.keys).to contain_exactly(
+        secret_first_post.id,
+        secret_reply.id,
+        public_post.id,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Category access changes that revoke public visibility do not invalidate existing Algolia post records, so plaintext indexed while public remains anonymously searchable after Discourse denies access. The fix adds an after_commit callback on Category that enqueues category-scoped indexing when read_restricted changes, re-evaluating every post in the category through the existing anonymous Guardian visibility check and deleting or re-indexing as appropriate.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1472

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>